### PR TITLE
Fixes #12 - Adds directoryUrl to Options

### DIFF
--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -13,6 +13,7 @@ public struct Options {
     public var folder: String = (Bundle.main.bundleIdentifier ?? "").appending("/Default")
     public var encoder: JSONEncoder = JSONEncoder()
     public var decoder: JSONDecoder = JSONDecoder()
+    public var directoryUrl: URL? = nil
 
     public init() {}
 }

--- a/Sources/Storage.swift
+++ b/Sources/Storage.swift
@@ -26,12 +26,17 @@ public class Storage {
     public init(options: Options) throws {
         self.options = options
 
-        let url = try fileManager.url(
-            for: options.searchPathDirectory,
-            in: .userDomainMask,
-            appropriateFor: nil,
-            create: true
-        )
+        var url: URL
+        if let directoryUrl = options.directoryUrl {
+            url = directoryUrl
+        } else {
+            url = try fileManager.url(
+                for: options.searchPathDirectory,
+                in: .userDomainMask,
+                appropriateFor: nil,
+                create: true
+            )
+        }
 
         self.folderUrl = url
             .appendingPathComponent(options.folder, isDirectory: true)


### PR DESCRIPTION
This fixes issue #12 by adding a `directoryUrl` variable to `Options`.

An alternative could be create an enum that could container the searchPathDirectory or a directory url instead.