### PR TITLE
Add option to bypass in-memory cache

### DIFF
--- a/Sources/Options.swift
+++ b/Sources/Options.swift
@@ -15,6 +15,9 @@ public struct Options {
 
     /// Optionally, you can set predefined directory for where to save files
     public var directoryUrl: URL? = nil
+    
+    /// Set to false to by-pass in-memory cache
+    public var useMemoryCache: Bool = true
 
     public var encoder: JSONEncoder = JSONEncoder()
     public var decoder: JSONDecoder = JSONDecoder()

--- a/Sources/Storage.swift
+++ b/Sources/Storage.swift
@@ -120,14 +120,15 @@ extension Storage {
             }
         }
         
-        if let object = cache.object(forKey: key as NSString) as? T {
-            return object
-        } else {
-            let data = try Data(contentsOf: fileUrl(forKey: key))
-            let object = try fromData(data)
-            cache.setObject(object as AnyObject, forKey: key as NSString)
+        if self.options.useMemoryCache,
+            let object = cache.object(forKey: key as NSString) as? T {
             return object
         }
+
+        let data = try Data(contentsOf: fileUrl(forKey: key))
+        let object = try fromData(data)
+        cache.setObject(object as AnyObject, forKey: key as NSString)
+        return object
     }
 }
 

--- a/Sources/Storage.swift
+++ b/Sources/Storage.swift
@@ -29,6 +29,7 @@ public class Storage {
         var url: URL
         if let directoryUrl = options.directoryUrl {
             url = directoryUrl
+            self.folderUrl = directoryUrl
         } else {
             url = try fileManager.url(
                 for: options.searchPathDirectory,
@@ -36,10 +37,8 @@ public class Storage {
                 appropriateFor: nil,
                 create: true
             )
+            self.folderUrl = url.appendingPathComponent(options.folder, isDirectory: true)
         }
-
-        self.folderUrl = url
-            .appendingPathComponent(options.folder, isDirectory: true)
 
         try createDirectoryIfNeeded(folderUrl: folderUrl)
         try applyAttributesIfAny(folderUrl: folderUrl)


### PR DESCRIPTION
As mentioned in #16, iOS widgets use a different memory cache to the iOS app. This PR adds a bool to `Options` which allows the user to bypass the memory cache and always read from the on-disk cache in situations like this when the in-memory cache can end up out-of-date.

I wasn't sure if there's a good way to test this but I'm happy to add a test if anyone has a suggestion for how to structure it, too.